### PR TITLE
[WIP]itemコントローラーのindexアクション修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,45 +4,18 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
 
   def index
-
-  items = Item.all
-  ladies, mens, electro, hobby, other = [], [], [], [], []
-
-  items.each do |item|
-    if item.category.parent.parent.id == 1
-      ladies << item.category.id
-    elsif item.category.parent.parent.id == 2
-      mens << item.category.id
-    elsif item.category.parent.parent.id == 3
-      electro << item.category.id
-    elsif item.category.parent.parent.id == 4
-      hobby << item.category.id
-    elsif item.category.parent.parent.id == 5
-      other << item.category.id
-    end
-
-  end
-
-  # 重複している値を弾く
-  ladies_id = ladies.uniq
-  mens_id = mens.uniq
-  electro_id = electro.uniq
-  hobby_id = hobby.uniq
-  other_id = other.uniq
-
   # カテゴリー変数の作成
-  @ladies =Item.update_desc.limit(10).where(category_id: ladies_id)
-  @mens =Item.update_desc.limit(10).where(category_id: mens_id)
-  @hobbies =Item.update_desc.limit(10).where(category_id: hobby_id)
-  @electros =Item.update_desc.limit(10).where(category_id: electro_id)
-  @others =Item.update_desc.limit(10).where(category_id: other_id)
+  @ladies =Item.incl.update_desc.limit(10).ladies
+  @mens =Item.incl.update_desc.limit(10).mens
+  @electros =Item.incl.update_desc.limit(10).electro
+  @hobbies =Item.incl.update_desc.limit(10).hobby
+  @others =Item.incl.update_desc.limit(10).other
 
   # ブランド変数の作成
   @chanel = Item.cha
   @louis = Item.louis
   @supreme = Item.sup
   @nike = Item.nike
-
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,15 +24,21 @@ class Item < ApplicationRecord
   validates :prefecture_id, presence: true
   validates :category_id, presence: true
 
+  scope :incl, -> { includes(:images) }
+
+  scope :ladies,  -> { where(category_id: 8..13) }
+  scope :mens,  -> { where(category_id: 16..21) }
+  scope :electro,  -> { where(category_id: 25..42) }
+  scope :hobby,  -> { where(category_id: 46..62) }
+  scope :other,  -> { where(category_id: 65..70) }
+
   scope :cha, -> { where(brand_id: 1) }
   scope :louis, -> { where(brand_id: 3) }
   scope :sup, -> { where(brand_id: 4) }
   scope :nike, -> { where(brand_id: 2) }
 
-  extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to_active_hash :prefecture
-
   scope :update_desc, ->{order("updated_at DESC")}
 
-
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
 end


### PR DESCRIPTION
# What
itemsコントローラのindexアクションでアイテムをallで呼び出していたのを修正。
development.logの内容がindex画面だけで膨大になってしまうので、whereで条件に当てはまるものだけを呼び出すようにした。